### PR TITLE
Cambia actualización de user

### DIFF
--- a/aparkapp/api/views.py
+++ b/aparkapp/api/views.py
@@ -131,7 +131,7 @@ class AnnouncementAPI(APIView):
         announcement = self.get_object(pk)
 
         data = request.data.copy()
-        data['user'] = request.user.id
+        data['user'] = announcement.user.id
 
         #Coordinates to address
         coordinates = (float(data['latitude']), float(data['longitude']))


### PR DESCRIPTION
Se ha corregido que al actualizar un anuncio se cambie el id del usuario (dueño del anuncio) si el que edita el campo es otro usuario.