### PR TITLE
Cancelar y editar anuncio

### DIFF
--- a/aparkapp/api/serializers.py
+++ b/aparkapp/api/serializers.py
@@ -79,7 +79,7 @@ class SwaggerAnnouncementSerializer(serializers.ModelSerializer):
     class Meta:
         model = Announcement
         fields = ['id','date','wait_time','price','allow_wait','location', 'longitude', 'latitude',
-        'zone', 'limited_mobility', 'status', 'observation', 'rated', 'vehicle']
+        'zone', 'limited_mobility', 'status', 'observation', 'rated', 'announcement', 'vehicle']
 
 class SwaggerUpdateAnnouncementSerializer(serializers.ModelSerializer):
     class Meta:


### PR DESCRIPTION
-Se han modificado los endpoints de editar y cancelar anuncios para
que no permitan a los usuarios usar esos endpoints si el anuncio
ya está reservado
-También se ha añadido una restricción para que los usuarios no
puedan editar o cancelar anuncios de otros usuarios
-Se han añadido los tests correspondientes para la nueva casuística