### PR TITLE
Registra usuario

### DIFF
--- a/aparkapp/api/views.py
+++ b/aparkapp/api/views.py
@@ -133,24 +133,24 @@ class ProfileApi(APIView):
     permission_classes = [IsAuthenticated]
     model=Profile
 
-    def get_object(self,pk):
+    def get_object(self,user):
         try:
-            return Profile.objects.get(id=pk)
+            return Profile.objects.get(user=user)
         except Profile.DoesNotExist:
             raise Http404
 
     @swagger_auto_schema(request_body=SwaggerProfileSerializer)
     def put(self, request, *args, **kwargs):
-        pk = request.user.id
-        user = self.get_object(pk)
-        serializer = ProfileSerializer(user, data=request.data, partial=True)
+        user = request.user
+        profile = self.get_object(user)
+        serializer = ProfileSerializer(profile,data=request.data, partial=True, context={'request': request})
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(serializer.data, status=status.HTTP_200_OK)
     
     def get(self, request):
-        pk = request.user.id
-        return Response(ProfileSerializer(get_object_or_404(Profile, pk=pk)).data)
+
+        return Response(ProfileSerializer(get_object_or_404(Profile, user=request.user)).data)
 
 
 class AnnouncementsAPI(generics.ListCreateAPIView):
@@ -502,7 +502,7 @@ class RegisterAPI(APIView):
     @swagger_auto_schema(request_body=RegisterSerializer)
     def post(self, request):
         data = request.data.copy()
-        serializer_data = RegisterSerializer(data=data)
+        serializer_data = RegisterSerializer(data=data, context={'request': request})
         if serializer_data.is_valid():
             serializer_data.save()
             return Response({"mensaje":"Registrado correctamente","user":serializer_data.data},status=status.HTTP_201_CREATED)       


### PR DESCRIPTION
-Se han añadido las restricciones de mayoría de edad y de número
de teléfono único, tanto para el registro de usuario como para
la actualización del perfil
-Se ha mejorado el endpoint que permitía actualizar perfiles, ya que
si los id del perfil y del usuario no coincidía, se actualizaba el
perfil de un usuario distinto
-Se han añadido los test correspondientes