### PR TITLE
Eliminación endpoint auxiliar

### DIFF
--- a/aparkapp/api/serializers.py
+++ b/aparkapp/api/serializers.py
@@ -106,7 +106,7 @@ class AnnouncementNestedVehicleSerializer(serializers.ModelSerializer):
     class Meta:
         model = Announcement
         fields = '__all__'
-        
+
 class SwaggerAnnouncementSerializer(serializers.ModelSerializer):
     class Meta:
         model = Announcement
@@ -147,6 +147,11 @@ class SwaggerCancelReservationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Reservation
         fields = ['cancelled']
+
+class SimpleReservationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Reservation
+        fields = ['id', 'cancelled']
 
 
 ### GEOLOCATION SERIALIZERS
@@ -204,3 +209,12 @@ class RegisterSerializer(serializers.ModelSerializer):
             Vehicle.objects.create(user=user, **vehicle_data)
 
         return user
+
+###
+class AnnouncementNestedReservationsSerializer(serializers.ModelSerializer):
+    vehicle = VehicleSerializer(read_only = True)
+    reservation_set = SimpleReservationSerializer(many=True)
+    class Meta:
+        model = Announcement
+        fields = ['id','date','wait_time','price','allow_wait','location', 'longitude', 'latitude',
+        'zone', 'limited_mobility', 'status', 'observation', 'rated', 'announcement', 'vehicle', 'reservation_set']

--- a/aparkapp/api/views.py
+++ b/aparkapp/api/views.py
@@ -250,8 +250,8 @@ class AnnouncementsAPI(generics.ListCreateAPIView):
         query2 = Vehicle.objects.filter(user=user)
 
         if query:
-            if query.get().cancelled:
-                res=Response("El anuncio ya está reservado", status=status.HTTP_409_CONFLICT)    
+            if not query.get().cancelled:
+                res=Response("El anuncio ya existe", status=status.HTTP_409_CONFLICT)    
         if query2:
             vhs = query2.all().values()
             ls = [v['id'] for v in vhs]

--- a/aparkapp/api/views.py
+++ b/aparkapp/api/views.py
@@ -30,7 +30,7 @@ from api.serializers import (AnnouncementNestedVehicleSerializer,
                              SwaggerVehicleSerializerId,
                              UserNestedProfileSerializer, UserSerializer,
                              VehicleSerializer, VehicleSerializerId,
-                             RatingSerializer, SwaggerRatingSerializer)
+                             RatingSerializer, SwaggerRatingSerializer, AnnouncementNestedReservationsSerializer)
 from rest_framework_simplejwt.views import TokenObtainPairView
 from .geolocator import address_to_coordinates, coordinates_to_address
 from .models import Announcement, Profile, Rating, Reservation, User, Vehicle
@@ -271,7 +271,7 @@ class myAnnouncementsAPI(APIView):
 
     def get(self, request):
         announcements = Announcement.objects.filter(user=request.user).order_by('date')
-        serializer_class = AnnouncementNestedVehicleSerializer(announcements,many=True)
+        serializer_class = AnnouncementNestedReservationsSerializer(announcements,many=True)
 
         return Response(serializer_class.data)
 


### PR DESCRIPTION
Se ha eliminado el endpoint auxiliar que permitia saber si un anuncio
tenia reservas asociadas. Esta información se transmitirá por otro
endpoint existente para ahorrar llamadas a la API.