### PR TITLE
Modificación modelo de anuncio y cambio en serializador de reserva

### DIFF
--- a/aparkapp/api/models.py
+++ b/aparkapp/api/models.py
@@ -122,7 +122,7 @@ class Announcement(models.Model):
    n_extend = models.IntegerField(validators=[MinValueValidator(0), MaxValueValidator(3)], default=0)
 
    #Relationship
-   vehicle = models.ForeignKey(Vehicle, on_delete=models.SET_NULL, null = True)
+   vehicle = models.ForeignKey(Vehicle, on_delete=models.RESTRICT)
    user = models.ForeignKey(User, on_delete=models.CASCADE)
 
    def __str__(self):

--- a/aparkapp/api/serializers.py
+++ b/aparkapp/api/serializers.py
@@ -190,7 +190,7 @@ class SwaggerCancelReservationSerializer(serializers.ModelSerializer):
 class SimpleReservationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Reservation
-        fields = ['id', 'cancelled']
+        fields = ['id', 'rated', 'cancelled']
 
 
 ### GEOLOCATION SERIALIZERS


### PR DESCRIPTION
Solucionado error con el borrado en cascada de vehículo-anuncio
y añadido campo necesario en el serializador de reserva