### PR TITLE
Modificación código de error al eliminar vehículos

### DIFF
--- a/aparkapp/api/serializers.py
+++ b/aparkapp/api/serializers.py
@@ -30,7 +30,7 @@ class ProfileSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("Ya existe un usuario registrado con el mismo número de teléfono")
         return value
 
-class ProfileRegisterSerializer(serializers.ModelSerializer): ## CHEEECCCCCCCCCCCCCCCCCCCKKKKKKK
+class ProfileRegisterSerializer(serializers.ModelSerializer): 
     class Meta:
         model = Profile
         fields = ['phone', 'birthdate', 'is_banned']


### PR DESCRIPTION
Se ha modificado el código de error a un 409 al eliminar un vehículo
que se encuentra asociado a un anuncio