### PR TITLE
Solución error 500 al buscar plaza

### DIFF
--- a/aparkapp/api/geolocator.py
+++ b/aparkapp/api/geolocator.py
@@ -15,7 +15,7 @@ def address_to_coordinates(query, county_code="ES", only_one_result=False, raw=T
         else:
            locations=[loc for loc in res]  
     except Exception:
-        raise ValueError
+        return False
     return locations
     
 # Returns address given a tuple with coordinates

--- a/aparkapp/api/views.py
+++ b/aparkapp/api/views.py
@@ -507,9 +507,13 @@ class GeolocationToCoordinatesAPI(APIView):
     def post(self, request):
         serializer = GeolocationToCoordinatesSerializer(data=request.data)
         if serializer.is_valid():
-            response=Response(address_to_coordinates(request.data['location'],
+            address = address_to_coordinates(request.data['location'],
             request.data.get('country_code', 'ES'), bool(request.data.get('one_result', 'false')),
-            request.data.get('raw', 'true')), status=status.HTTP_200_OK)            
+            request.data.get('raw', 'true'))
+            if address:
+                response=Response(address, status=status.HTTP_200_OK)
+            else:
+                response=Response("Ubicación no encontrada", status=status.HTTP_404_NOT_FOUND)
         else:
             response=Response("Petición incorrecta", status=status.HTTP_400_BAD_REQUEST)
         return response


### PR DESCRIPTION
Se ha solucionado un error al no poder pasar de ubicación a coordenadas.
Ahora en caso de que no se encuentre la ubicación, devolverá 404